### PR TITLE
Escape strings and chars when serializing

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -121,12 +121,12 @@ impl<W: Write> ser::Serializer for &mut Uneval<W> {
     }
 
     fn serialize_char(self, v: char) -> SerResult {
-        write!(self.writer, "'{}'", v)?;
+        write!(self.writer, "{:?}", v)?;
         Ok(())
     }
 
     fn serialize_str(self, v: &str) -> SerResult {
-        write!(self.writer, "\"{}\".into()", v)?;
+        write!(self.writer, "{:?}.into()", v)?;
         Ok(())
     }
 

--- a/test_fixtures/data.toml
+++ b/test_fixtures/data.toml
@@ -171,3 +171,19 @@ value = """
     }
 }
 """
+
+[escapist_strings]
+main_type = "Foo"
+definition = """
+#[derive(PartialEq, Debug, Serialize)]
+pub struct Foo {
+  pub s: Vec<String>,
+  pub c: Vec<char>,
+}
+"""
+value = """
+definition::Foo {
+    s: vec!["\\"".into(), "\\n".into()],
+    c: vec!['\\'', '\\n'],
+}
+"""


### PR DESCRIPTION
I tried using uneval to build something terrible. Anyway, the data included newlines, apostrophes and quote marks, and I was passing those to uneval as both strings and chars. This turned out problematic.

This PR changes serialization of strings and chars to use their Debug formatting rather than the Display one, which makes sure characters that require escaping are escaped.