### PR TITLE
Implement boxing of values with .into()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,15 @@
 //! };
 //! ```
 //!
+//! ### Boxed values
+//!
+//! Because `serde` applies `Deref`, there's no way to determine whether an underlying type is
+//! boxed or not. We solve this by emitting `.into()` after most values, which will box the value
+//! if necessary depending on the context.
+//!
+//! This doesn't work perfectly (for instance, it doesn't work for boxed tuples), but it works well
+//! enough to permit boxing of struct, enum, and option values.
+//!
 //! ## Limitations
 //! There are some cases when `uneval` will be unable to generate valid code. Namely:
 //! 1. Since Serde doesn't provide us the full path to the type in question (and in most cases it's simply unable to),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -36,6 +36,11 @@ impl<W: Write> Uneval<W> {
         Ok(())
     }
 
+    fn dot_into(&mut self) -> SerResult {
+        write!(self.writer, ".into()")?;
+        Ok(())
+    }
+
     fn serialize_item(&mut self, item: impl ser::Serialize) -> SerResult {
         self.comma()?;
         item.serialize(self)?;
@@ -56,87 +61,108 @@ impl<W: Write> ser::Serializer for &mut Uneval<W> {
     type SerializeStructVariant = Self;
 
     fn serialize_bool(self, v: bool) -> SerResult {
-        write!(self.writer, "{}", v)?;
+        write!(self.writer, "({})", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_i8(self, v: i8) -> SerResult {
-        write!(self.writer, "{}i8", v)?;
+        write!(self.writer, "({}i8)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_i16(self, v: i16) -> SerResult {
-        write!(self.writer, "{}i16", v)?;
+        write!(self.writer, "({}i16)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_i32(self, v: i32) -> SerResult {
-        write!(self.writer, "{}i32", v)?;
+        write!(self.writer, "({}i32)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_i64(self, v: i64) -> SerResult {
-        write!(self.writer, "{}i64", v)?;
+        write!(self.writer, "({}i64)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_i128(self, v: i128) -> SerResult {
-        write!(self.writer, "{}i128", v)?;
+        write!(self.writer, "({}i128)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_u8(self, v: u8) -> SerResult {
-        write!(self.writer, "{}u8", v)?;
+        write!(self.writer, "({}u8)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_u16(self, v: u16) -> SerResult {
-        write!(self.writer, "{}u16", v)?;
+        write!(self.writer, "({}u16)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_u32(self, v: u32) -> SerResult {
-        write!(self.writer, "{}u32", v)?;
+        write!(self.writer, "({}u32)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_u64(self, v: u64) -> SerResult {
-        write!(self.writer, "{}u64", v)?;
+        write!(self.writer, "({}u64)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_u128(self, v: u128) -> SerResult {
-        write!(self.writer, "{}u128", v)?;
+        write!(self.writer, "({}u128)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_f32(self, v: f32) -> SerResult {
-        write!(self.writer, "{}f32", v)?;
+        write!(self.writer, "({}f32)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_f64(self, v: f64) -> SerResult {
-        write!(self.writer, "{}f64", v)?;
+        write!(self.writer, "({}f64)", v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_char(self, v: char) -> SerResult {
         write!(self.writer, "'{}'", v.escape_default().collect::<String>())?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_str(self, v: &str) -> SerResult {
-        write!(self.writer, "\"{}\".into()", v.escape_default().collect::<String>())?;
+        write!(
+            self.writer,
+            "\"{}\"",
+            v.escape_default().collect::<String>()
+        )?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_bytes(self, v: &[u8]) -> SerResult {
         self.collect_seq(v)?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_none(self) -> SerResult {
         write!(self.writer, "None")?;
+        self.dot_into()?;
         Ok(())
     }
 
@@ -147,16 +173,19 @@ impl<W: Write> ser::Serializer for &mut Uneval<W> {
         write!(self.writer, "Some(")?;
         value.serialize(&mut *self)?;
         write!(self.writer, ")")?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_unit(self) -> SerResult {
         write!(self.writer, "()")?;
+        self.dot_into()?;
         Ok(())
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> SerResult {
         write!(self.writer, "{}", name)?;
+        self.dot_into()?;
         Ok(())
     }
 
@@ -167,6 +196,7 @@ impl<W: Write> ser::Serializer for &mut Uneval<W> {
         variant: &'static str,
     ) -> SerResult {
         write!(self.writer, "{}::{}", name, variant)?;
+        self.dot_into()?;
         Ok(())
     }
 
@@ -177,6 +207,7 @@ impl<W: Write> ser::Serializer for &mut Uneval<W> {
         write!(self.writer, "{}(", name)?;
         value.serialize(&mut *self)?;
         write!(self.writer, ")")?;
+        self.dot_into()?;
         Ok(())
     }
 
@@ -193,6 +224,7 @@ impl<W: Write> ser::Serializer for &mut Uneval<W> {
         write!(self.writer, "{}::{}(", name, variant)?;
         value.serialize(&mut *self)?;
         write!(self.writer, ")")?;
+        self.dot_into()?;
         Ok(())
     }
 
@@ -267,6 +299,7 @@ impl<W: Write> ser::SerializeSeq for &mut Uneval<W> {
 
     fn end(self) -> SerResult {
         write!(self.writer, "].into_iter().collect()")?;
+        // Note: no .into() after collect, because types cannot be inferred.
         self.inside = true;
         Ok(())
     }
@@ -284,6 +317,7 @@ impl<W: Write> ser::SerializeTuple for &mut Uneval<W> {
 
     fn end(self) -> SerResult {
         write!(self.writer, ")) }}")?;
+        // Note: .into() doesn't work for tuples
         self.inside = true;
         Ok(())
     }
@@ -301,6 +335,7 @@ impl<W: Write> ser::SerializeTupleStruct for &mut Uneval<W> {
 
     fn end(self) -> SerResult {
         write!(self.writer, ")")?;
+        self.dot_into()?;
         self.inside = true;
         Ok(())
     }
@@ -318,6 +353,7 @@ impl<W: Write> ser::SerializeTupleVariant for &mut Uneval<W> {
 
     fn end(self) -> SerResult {
         write!(self.writer, ")")?;
+        self.dot_into()?;
         self.inside = true;
         Ok(())
     }
@@ -348,6 +384,7 @@ impl<W: Write> ser::SerializeMap for &mut Uneval<W> {
 
     fn end(self) -> SerResult {
         write!(self.writer, "].into_iter().collect()")?;
+        // Note: no .into() after collect, because types cannot be inferred.
         self.inside = true;
         Ok(())
     }
@@ -372,6 +409,7 @@ impl<W: Write> ser::SerializeStruct for &mut Uneval<W> {
 
     fn end(self) -> SerResult {
         write!(self.writer, "}}")?;
+        self.dot_into()?;
         self.inside = true;
         Ok(())
     }
@@ -396,6 +434,7 @@ impl<W: Write> ser::SerializeStructVariant for &mut Uneval<W> {
 
     fn end(self) -> SerResult {
         write!(self.writer, "}}")?;
+        self.dot_into()?;
         self.inside = true;
         Ok(())
     }

--- a/test_fixtures/data.toml
+++ b/test_fixtures/data.toml
@@ -187,3 +187,46 @@ definition::Foo {
     c: vec!['\\'', '\\n', '"', '❤'],
 }
 """
+
+[box_issue_1]
+main_type = "Foo"
+support_types = "InnerStruct,InnerEnum"
+definition = """
+#[derive(PartialEq, Debug, Serialize)]
+pub struct Foo {
+  pub boxed_struct: Box<InnerStruct>,
+  pub enum_unit: Box<InnerEnum>,
+  pub enum_tuple: Box<InnerEnum>,
+  pub enum_struct: Box<InnerEnum>,
+  pub num: Box<i64>,
+  pub some: Box<Option<bool>>,
+  pub none: Box<Option<bool>>,
+  pub unit: Box<()>,
+  pub str: Box<str>,
+}
+#[derive(PartialEq, Debug, Serialize)]
+pub struct InnerStruct {
+  pub n: u64,
+}
+#[derive(PartialEq, Debug, Serialize)]
+pub enum InnerEnum {
+  Unit,
+  Tuple(i64),
+  Struct { n: i64 },
+}
+
+
+"""
+value = """
+definition::Foo {
+    boxed_struct: Box::new(definition::InnerStruct {n: 42}),
+	enum_unit: Box::new(definition::InnerEnum::Unit),
+	enum_tuple: Box::new(definition::InnerEnum::Tuple(-42)),
+	enum_struct: Box::new(definition::InnerEnum::Struct {n: 42}),
+	num: Box::new(-42),
+	some: Box::new(Some(true)),
+	none: Box::new(None),
+	unit: Box::new(()),
+	str: "123".into(),
+}
+"""


### PR DESCRIPTION
I ran into issues using `uneval` to serialize a recursive type, which required `Box<T>` for some of its children.

This PR tweaks the serialization code to emit a `.into()` call after (almost) every value. This will either do nothing, or coerce the value into the right type (which can have the effect of putting it in a `Box<T>`, but also an `Arc<T>`, etc.).

This (sort of?) solves #1---not in every case, but in enough cases to let you use `uneval` with recursive types. Notably, boxed tuples don't work.